### PR TITLE
Fix hook requirements

### DIFF
--- a/islandora_cwrc_basexdb.install
+++ b/islandora_cwrc_basexdb.install
@@ -21,8 +21,8 @@ function islandora_cwrc_basexdb_requirements($phase) {
   else {
     $requirements['islandora_cwrc_basexdb']['severity'] = REQUIREMENT_ERROR;
     $requirements['islandora_cwrc_basexdb']['value'] = $library['error'];
-    $requirements['islandora_cwrc_basexdb']['description'] = $t('The <a href="@url">BaseX PHP client Library</a> is missing. <a href="@download">Download @library-file</a> and extract it into the <code>@directory</code> directory. Add the folder <code>@library-folder</code>.', array(
-        '@cwrc' => 'https://github.com/BaseXdb/basex',
+    $requirements['islandora_cwrc_basexdb']['description'] = $t('The <a href="@url">BaseX PHP client Library</a> is missing. <a href="@download">Download</a> and extract into the <code>@directory</code> directory. Rename folder <code>@library-folder</code>.', array(
+        '@url' => 'https://github.com/cwrc/basex-api',
         '@download' => 'https://github.com/cwrc/basex-api/archive/master.zip',
         '@directory' => 'sites/default/libraries',
         '@library-folder' => 'basex-api')
@@ -58,4 +58,3 @@ function islandora_cwrc_basexdb_uninstall() {
     variable_del($variable);
   }
 }
-

--- a/islandora_cwrc_basexdb.install
+++ b/islandora_cwrc_basexdb.install
@@ -21,12 +21,11 @@ function islandora_cwrc_basexdb_requirements($phase) {
   else {
     $requirements['islandora_cwrc_basexdb']['severity'] = REQUIREMENT_ERROR;
     $requirements['islandora_cwrc_basexdb']['value'] = $library['error'];
-    $requirements['islandora_cwrc_basexdb']['description'] = $t('The <a href="@url">BaseX PHP client Library</a> is missing. <a href="@download">Download @library-file</a> and extract it into the <code>@directory</code> directory. Add the folder <code>@library-folder</code> and add @library-file.', array(
+    $requirements['islandora_cwrc_basexdb']['description'] = $t('The <a href="@url">BaseX PHP client Library</a> is missing. <a href="@download">Download @library-file</a> and extract it into the <code>@directory</code> directory. Add the folder <code>@library-folder</code>.', array(
         '@cwrc' => 'https://github.com/BaseXdb/basex',
-        '@download' => 'https://github.com/BaseXdb/basex/blob/master/basex-api/src/main/php/BaseXClient.php',
-        '@directory' => 'sites/all/libraries',
-        '@library-folder' => 'basex-api',
-        '@library-file' => 'BaseXClient.php')
+        '@download' => 'https://github.com/cwrc/basex-api/archive/master.zip',
+        '@directory' => 'sites/default/libraries',
+        '@library-folder' => 'basex-api')
     );
   }
   return $requirements;

--- a/islandora_cwrc_basexdb.module
+++ b/islandora_cwrc_basexdb.module
@@ -72,9 +72,9 @@ function islandora_cwrc_basexdb_libraries_info() {
   // Support for BaseX, the XML Database.
   $libraries['basex-api'] = array(
     'name' => 'CWRC BaseX XML Database',
-    'vendor url' => 'https://github.com/BaseXdb/basex',
-    'download url' => 'https://github.com/BaseXdb/basex/blob/master/basex-api/src/main/php/BaseXClient.php',
-    'download file url' => 'https://raw.githubusercontent.com/BaseXdb/basex/master/basex-api/src/main/php/BaseXClient.php',
+    'vendor url' => 'https://github.com/cwrc/basex-api',
+    'download url' => 'https://github.com/cwrc/basex-api/BaseXClient.php',
+    'download file url' => 'https://raw.githubusercontent.com/cwrc/basex-api/master/BaseXClient.php',
     'version arguments' => array(
       'file' => 'BaseXClient.php',
       'pattern' => '@Works with BaseX ([0-9a-zA-Z\.-]+) and later@',


### PR DESCRIPTION
The original pull request and the pre-existing code referenced the wrong location for the basex-api. Currently, a local copy of the client code was moved into the CWRC repo an altered to prevent class name conflicts. The pull request updates the location information